### PR TITLE
Chunked output support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,6 @@ Sending a number as `msg.payload` will change the frequency of the LFO. Sending 
 - square
 - sig
 
-Beware of setting the sampling rate too low as it may hog your CPU.
+Beware of setting the sampling rate too low as it may hog your CPU.  To avoid CPU hogging, chunked output can be activated: when chunk size is set to N, then only every N-th sample an output message will be send (containing an array of N samples).
+
+An example flow is available via the Node-RED flow editor menu: Import / Examples / Lfo

--- a/lfo/lfo.html
+++ b/lfo/lfo.html
@@ -6,7 +6,9 @@
             name: {value:""},
             waveform: {value: "sine"},
             frequency: {value: 1, validate:RED.validators.number()},
-            samplingrate: {value: 20, validate:RED.validators.number()}
+            samplingrate: {value: 20, validate:RED.validators.number()},
+            chunked: {value: false},
+            chunksize: {value: 1, validate: function(v) { return !v || !isNaN(v) }}
         },
         inputs:1,
         outputs:1,
@@ -18,6 +20,19 @@
         oneditprepare: function () {
             $( "#node-input-frequency" ).spinner({min:0});
             $( "#node-input-samplingrate" ).spinner({min:1});
+            
+            // Older nodes don't have a chunksize yet, so let's migrate them to have chunksize 1
+            // (only relevant the first time config screen will be opened)
+            $('#node-input-chunksize').val(this.chunksize || 1);
+            
+            // Show the 'chunksize' field only when the 'chunked' checkbox is checked
+            $("#node-input-chunked").change(function() {
+                if ($(this).is(":checked")) {
+                    $(".node-input-chunksize-row").show();
+                } else {
+                    $(".node-input-chunksize-row").hide();
+                }
+            });
         }
     });
 </script>
@@ -44,6 +59,15 @@
         <input type="text" id="node-input-samplingrate" placeholder="ms" style="text-align:end; width:50px !important">
         <span>Milisecond(s)</span>
     </div>
+    <div class="form-row">    
+        <input type="checkbox" id="node-input-chunked" style="display: inline-block; width: auto; vertical-align: top;">
+        <label for="node-input-chunked" style="width:70%;"> Collect samples in chunks of fixed size</label>
+        <div style="margin-left: 20px" class="node-input-chunksize-row hide">
+            <label for="node-input-chunksize" style="width: 120px;"><i class="fa fa-bars"></i> Chunk size</label>
+            <input type="text" id="node-input-chunksize" pattern="[1-9][0-9]*" style="text-align:end; width:50px !important">
+            <span>Sample(s)</span>
+        </div>
+    </div>
 
     <div class="form-row">
         <label for="node-input-name" style="width: 120px;"><i class="icon-tag"></i> Name</label>
@@ -66,4 +90,5 @@
     </ul>
     </p>
     <p>Beware of setting the sampling rate too low as it may hog your CPU.</p>
+    <p>To avoid CPU hogging, chunked output can be activated: when chunk size is set to N, then only every N-th sample an output message will be send (containing an array of N samples).</p>
 </script>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-lfo",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Low frequency oscillators for Node-RED",
   "dependencies": {
     "oscillators": "0.6.0",
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "https://github.com/natcl/node-red-contrib-lfo.git"
   },
-  "keywords": ["node-red", "lfo", "oscillator"],
+  "keywords": ["node-red", "lfo", "oscillator", "generator", "wave", "sine", "saw", "triangle", "square", "sig"],
   "node-red": {
     "nodes": {
       "lfo": "lfo/lfo.js"


### PR DESCRIPTION
Hello Nathanaël ( @natcl ),

Thank you for sharing this nice node!

Currently the node sends an output message for every sample.  Since I want to use it to simulate raw audio chunks, I have added support for chunked output.  When chunked output is enabled with chunk size N, then every N-th sample an output message will be generated (which contains an **array** of N samples).

In the beginning I wanted to create a NodeJs **buffer** (instead of an array) similar to WAV chunks: i.e. creating a buffer of size N and appending N samples to the buffer.  But I'm not sure how to add the numeric values correctly to the buffer ...  If you have any suggestions, please be my guest !!

Hope you find this PR useful...

Kind regards
Bart Butenaers

## Config screen
When the checkbox is checked, an input field appears to enter integer values greater than 1 (otherwise the box is highlighted as error):

![image](https://user-images.githubusercontent.com/14224149/57730858-aa417080-7699-11e9-939c-3f86bc8a2e5d.png)

## Info panel
Paragraph added:

![image](https://user-images.githubusercontent.com/14224149/57730923-ce04b680-7699-11e9-8c56-3d21cf50e14e.png)

## Readme page
Paragraph added:

![image](https://user-images.githubusercontent.com/14224149/57731011-06a49000-769a-11e9-9084-853300186932.png)

P.S. I added the example line, because I wasn't aware at the beginning that you had provided examples ...

## Package.json
The version number has been changed from 1.0.0 to 1.1.0, because there shouldn't be impact on existing flows:
+ When you upgrade without opening the config screen, the chunked output option is disabled by default.  So it will still keep sending an output message for every sample.
+ When you upgrade and open the config screen, the chunked output option is also disabled by default.

I have also added some keywords, because I was searching on '_wave generator_' and didn't found this node from the first time ...

## Example output
Example of chunked output for chunksize 20:

![image](https://user-images.githubusercontent.com/14224149/57731375-cd205480-769a-11e9-9970-7c1ae6034386.png)
